### PR TITLE
Added type definition for TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 package-lock.json
+.vscode

--- a/AHT20.d.ts
+++ b/AHT20.d.ts
@@ -1,0 +1,13 @@
+import i2c from 'i2c-bus';
+export default class AHT20 {
+    private readonly bus;
+    constructor(bus: i2c.PromisifiedBus);
+    static open(busNumber?: number): Promise<any>;
+    init(): Promise<any>;
+    getStatus(): Promise<any>;
+    reset(): Promise<any>;
+    calibrate(): Promise<any>;
+    readData(): Promise<any>;
+    temperature(): Promise<any>;
+    humidity(): Promise<any>;
+}

--- a/AHT20.d.ts
+++ b/AHT20.d.ts
@@ -2,12 +2,14 @@ import i2c from 'i2c-bus';
 export default class AHT20 {
     private readonly bus;
     constructor(bus: i2c.PromisifiedBus);
-    static open(busNumber?: number): Promise<any>;
-    init(): Promise<any>;
-    getStatus(): Promise<any>;
-    reset(): Promise<any>;
-    calibrate(): Promise<any>;
-    readData(): Promise<any>;
-    temperature(): Promise<any>;
-    humidity(): Promise<any>;
+    static open(busNumber?: number): Promise<AHT20>;
+    init(): Promise<boolean>;
+    getStatus(): Promise<number>;
+    reset(): Promise<boolean>;
+    calibrate(): Promise<boolean>;
+    readData(): Promise<{
+        [key: string]: number;
+    }>;
+    temperature(): Promise<number>;
+    humidity(): Promise<number>;
 }

--- a/AHT20.ts
+++ b/AHT20.ts
@@ -21,18 +21,18 @@ export default class AHT20 {
 		this.bus = bus;
 	}
 
-	static async open(busNumber: number = 1): Promise<any> {
+	static async open(busNumber: number = 1): Promise<AHT20> {
 		try {
 			const bus: i2c.PromisifiedBus = await i2c.openPromisified(busNumber);
 			const sensor: AHT20 = new AHT20(bus);
 			await sensor.init();
 			return sensor;
 		} catch (err: any) {
-			return err;
+			throw err;
 		}
 	}
 
-	async init(): Promise<any> {
+	async init(): Promise<boolean> {
 		try {
 			await sleep(20);
 			await this.reset();
@@ -42,32 +42,32 @@ export default class AHT20 {
 			}
 			return true;
 		} catch(err: any) {
-			return err;
+			throw err;
 		}
 	}
 
-	async getStatus(): Promise<any> {
+	async getStatus(): Promise<number> {
 		try {
 			const buf: Buffer = Buffer.alloc(1);
 			await this.bus.i2cRead(AHT20_I2CADDR, buf.length, buf);
 			return buf.readInt8();
 		} catch (err: any) {
-			return err;
+			throw err;
 		}
 	}
 
-	async reset(): Promise<any> {
+	async reset(): Promise<boolean> {
 		try {
 			const buf: Buffer = Buffer.from(AHT20_CMD_SOFTRESET);
 			await this.bus.i2cWrite(AHT20_I2CADDR, buf.length, buf);
 			await sleep(20);
 			return true;
 		} catch (err: any) {
-			return err;
+			throw err;
 		}
 	}
 
-	async calibrate(): Promise<any> {
+	async calibrate(): Promise<boolean> {
 		try {
 			const buf: Buffer = Buffer.from(AHT20_CMD_CALIBRATE);
 			await this.bus.i2cWrite(AHT20_I2CADDR, buf.length, buf);
@@ -80,11 +80,11 @@ export default class AHT20 {
 			}
 			return true;
 		} catch (err: any) {
-			return err;
+			throw err;
 		}
 	}
 
-	async readData(): Promise<any> {
+	async readData(): Promise<{[key: string]: number}> {
 		try {
 			const buf: Buffer = Buffer.from(AHT20_CMD_MEASURE);
 			await this.bus.i2cWrite(AHT20_I2CADDR, buf.length, buf);
@@ -104,25 +104,25 @@ export default class AHT20 {
 				temperature
 			};
 		} catch (err: any) {
-			return err;
+			throw err;
 		}
 	}
 
-	async temperature(): Promise<any> {
+	async temperature(): Promise<number> {
 		try {
 			const { temperature }: {[key: string]: number} = await this.readData();
 			return temperature;
 		} catch (err: any) {
-			return err;
+			throw err;
 		}
 	}
 
-	async humidity(): Promise<any> {
+	async humidity(): Promise<number> {
 		try {
 			const { humidity }: {[key: string]: number} = await this.readData();
 			return humidity;
 		} catch (err: any) {
-			return err;
+			throw err;
 		}
 	}
 }

--- a/AHT20.ts
+++ b/AHT20.ts
@@ -1,0 +1,140 @@
+/*
+  AHT20.js
+  A Node.js I2C module for the Adafruit AHT20 Humidity/Temperature Sensor.
+*/
+
+'use strict';
+
+import i2c from 'i2c-bus';
+
+const AHT20_I2CADDR: number = 0x38
+const AHT20_CMD_SOFTRESET: number[] = [0xBA]
+const AHT20_CMD_CALIBRATE: number[] = [0xE1, 0x08, 0x00]
+const AHT20_CMD_MEASURE: number[] = [0xAC, 0x33, 0x00]
+const AHT20_STATUS_BUSY: number = 0x80;
+const AHT20_STATUS_CALIBRATED: number = 0x08;
+
+export default class AHT20 {
+    private readonly bus: i2c.PromisifiedBus;
+
+	constructor(bus: i2c.PromisifiedBus) {
+		this.bus = bus;
+	}
+
+	static async open(busNumber: number = 1): Promise<any> {
+		try {
+			const bus: i2c.PromisifiedBus = await i2c.openPromisified(busNumber);
+			const sensor: AHT20 = new AHT20(bus);
+			await sensor.init();
+			return sensor;
+		} catch (err: any) {
+			return err;
+		}
+	}
+
+	async init(): Promise<any> {
+		try {
+			await sleep(20);
+			await this.reset();
+
+			if (!await this.calibrate()) {
+				throw('Could not calibrate!');
+			}
+			return true;
+		} catch(err: any) {
+			return err;
+		}
+	}
+
+	async getStatus(): Promise<any> {
+		try {
+			const buf: Buffer = Buffer.alloc(1);
+			await this.bus.i2cRead(AHT20_I2CADDR, buf.length, buf);
+			return buf.readInt8();
+		} catch (err: any) {
+			return err;
+		}
+	}
+
+	async reset(): Promise<any> {
+		try {
+			const buf: Buffer = Buffer.from(AHT20_CMD_SOFTRESET);
+			await this.bus.i2cWrite(AHT20_I2CADDR, buf.length, buf);
+			await sleep(20);
+			return true;
+		} catch (err: any) {
+			return err;
+		}
+	}
+
+	async calibrate(): Promise<any> {
+		try {
+			const buf: Buffer = Buffer.from(AHT20_CMD_CALIBRATE);
+			await this.bus.i2cWrite(AHT20_I2CADDR, buf.length, buf);
+			while (await this.getStatus() & AHT20_STATUS_BUSY) {
+				await sleep(10);
+			}
+
+			if(await this.getStatus() & AHT20_STATUS_CALIBRATED) {
+				return true;
+			}
+			return true;
+		} catch (err: any) {
+			return err;
+		}
+	}
+
+	async readData(): Promise<any> {
+		try {
+			const buf: Buffer = Buffer.from(AHT20_CMD_MEASURE);
+			await this.bus.i2cWrite(AHT20_I2CADDR, buf.length, buf);
+
+			while (await this.getStatus() & AHT20_STATUS_BUSY) {
+				await sleep(10);
+			}
+
+			const rbuf: Buffer = Buffer.alloc(7);
+			await this.bus.i2cRead(AHT20_I2CADDR, rbuf.length, rbuf);
+
+			const humidity: number = round(((rbuf[1] << 12) | (rbuf[2] << 4) | (rbuf[3] >> 4)) * 100 / 0x100000, 2);
+			const temperature: number = round((((rbuf[3] & 0xF) << 16) | (rbuf[4] << 8) | rbuf[5]) * 200.0 / 0x100000 - 50, 2);
+
+			return {
+				humidity,
+				temperature
+			};
+		} catch (err: any) {
+			return err;
+		}
+	}
+
+	async temperature(): Promise<any> {
+		try {
+			const { temperature }: {[key: string]: number} = await this.readData();
+			return temperature;
+		} catch (err: any) {
+			return err;
+		}
+	}
+
+	async humidity(): Promise<any> {
+		try {
+			const { humidity }: {[key: string]: number} = await this.readData();
+			return humidity;
+		} catch (err: any) {
+			return err;
+		}
+	}
+}
+
+const round = (value: number, dmp: number): number => {
+	return Math.round(value / Math.pow(10, -dmp)) / Math.pow(10, dmp);
+}
+
+const sleep = (duration: number): Promise<void> => {
+	return new Promise((resolve) => {
+		setTimeout(() => {
+				resolve();
+		}, duration)
+	})
+}

--- a/package.json
+++ b/package.json
@@ -27,5 +27,9 @@
   "homepage": "https://github.com/thomome/aht20-sensor#readme",
   "dependencies": {
     "i2c-bus": "^5.2.2"
+  },
+  "devDependencies": {
+    "@types/i2c-bus": "^5.1.0",
+    "typescript": "^5.2.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,101 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Enable incremental compilation */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es6",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
+    // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files */
+    // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
+
+    /* Emit */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+    // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
+    // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}


### PR DESCRIPTION
## Description
Added type definition for [TypeScript](https://www.typescriptlang.org/).

## Details
Added `AHT20.ts` and `AHT20.d.ts` in your repository.
The first file is the copy of the original source file with type definition for TypeScript. The second file is type definition file for TypeScript.
You can re-generate `AHT20.d.ts` from `AHT20.ts` by installing the TypeScript nom package (already added `devDependencies` in `package.json`) and typing `tsc` at the root of this repository. Note that this will overwrite `AHT20.js` (If you don't want to, add `"emitDeclarationOnly": true` in `tsconfig.json`).

You can still use your module with normal Node.js.

## How to review
Write TypeScript example code with your module imported. You will see that these is no error refer to type definition.