### PR TITLE
Added JSDoc and access modifiers

### DIFF
--- a/AHT20.d.ts
+++ b/AHT20.d.ts
@@ -24,33 +24,31 @@ export default class AHT20 {
      * @returns `true` if successfully initialized the sensor.
      * @throws An error that occurred while initializing the sensor.
      */
-    init(): Promise<boolean>;
+    private init;
     /**
      * Gets AHT20 sensor status.
      * @returns Sensor status
      * @throws An error that occurred while getting sensor status.
      */
-    getStatus(): Promise<number>;
+    private getStatus;
     /**
      * Resets AHT20 sensor.
      * @returns `true` if successfully reset the sensor.
      * @throws An error that occurred while resetting the sensor.
      */
-    reset(): Promise<boolean>;
+    private reset;
     /**
      * Calibrates AHT20 sensor.
      * @returns `true` if successfully calibrated the sensor.
      * @throws An error that occurred while calibrating the sensor.
      */
-    calibrate(): Promise<boolean>;
+    private calibrate;
     /**
      * Reads information from AHT20 sensor.
      * @returns Information dictionary with temperature and humidity data.
      * @throws An error that occurred while Reading the information.
      */
-    readData(): Promise<{
-        [key: string]: number;
-    }>;
+    private readData;
     /**
      * Gets temperature data from AHT20 sensor.
      * @returns Temperature gotten from the sensor in Celsius.

--- a/AHT20.d.ts
+++ b/AHT20.d.ts
@@ -1,15 +1,66 @@
 import i2c from 'i2c-bus';
+/**
+ * AHT20 sensor class with data read functions.
+ */
 export default class AHT20 {
+    /**
+     * Bus instance.
+     */
     private readonly bus;
+    /**
+     * Constructor
+     * @param bus bus instance
+     */
     constructor(bus: i2c.PromisifiedBus);
+    /**
+     * Opens i2c bus and connect to the AHT20 sensor.
+     * @param busNumber Target bus number to open. Default is 1.
+     * @returns AHT20 instance with opened bus instance. You can read information with this instance.
+     * @throws An error that occurred while opening i2c bus.
+     */
     static open(busNumber?: number): Promise<AHT20>;
+    /**
+     * Initializes AHT20 sensor.
+     * @returns `true` if successfully initialized the sensor.
+     * @throws An error that occurred while initializing the sensor.
+     */
     init(): Promise<boolean>;
+    /**
+     * Gets AHT20 sensor status.
+     * @returns Sensor status
+     * @throws An error that occurred while getting sensor status.
+     */
     getStatus(): Promise<number>;
+    /**
+     * Resets AHT20 sensor.
+     * @returns `true` if successfully reset the sensor.
+     * @throws An error that occurred while resetting the sensor.
+     */
     reset(): Promise<boolean>;
+    /**
+     * Calibrates AHT20 sensor.
+     * @returns `true` if successfully calibrated the sensor.
+     * @throws An error that occurred while calibrating the sensor.
+     */
     calibrate(): Promise<boolean>;
+    /**
+     * Reads information from AHT20 sensor.
+     * @returns Information dictionary with temperature and humidity data.
+     * @throws An error that occurred while Reading the information.
+     */
     readData(): Promise<{
         [key: string]: number;
     }>;
+    /**
+     * Gets temperature data from AHT20 sensor.
+     * @returns Temperature gotten from the sensor in Celsius.
+     * @throws An error that occurred while getting temperature data.
+     */
     temperature(): Promise<number>;
+    /**
+     * Gets humidity data from AHT20 sensor.
+     * @returns Humidity gotten from the sensor in RH%.
+     * @throws An error that occurred while getting humidity data.
+     */
     humidity(): Promise<number>;
 }

--- a/AHT20.ts
+++ b/AHT20.ts
@@ -37,7 +37,7 @@ export default class AHT20 {
      * @returns AHT20 instance with opened bus instance. You can read information with this instance.
      * @throws An error that occurred while opening i2c bus.
      */
-	static async open(busNumber: number = 1): Promise<AHT20> {
+	public static async open(busNumber: number = 1): Promise<AHT20> {
 		try {
 			const bus: i2c.PromisifiedBus = await i2c.openPromisified(busNumber);
 			const sensor: AHT20 = new AHT20(bus);
@@ -53,7 +53,7 @@ export default class AHT20 {
      * @returns `true` if successfully initialized the sensor.
      * @throws An error that occurred while initializing the sensor.
      */
-	async init(): Promise<boolean> {
+	private async init(): Promise<boolean> {
 		try {
 			await sleep(20);
 			await this.reset();
@@ -72,7 +72,7 @@ export default class AHT20 {
      * @returns Sensor status
      * @throws An error that occurred while getting sensor status.
      */
-	async getStatus(): Promise<number> {
+	private async getStatus(): Promise<number> {
 		try {
 			const buf: Buffer = Buffer.alloc(1);
 			await this.bus.i2cRead(AHT20_I2CADDR, buf.length, buf);
@@ -87,7 +87,7 @@ export default class AHT20 {
      * @returns `true` if successfully reset the sensor.
      * @throws An error that occurred while resetting the sensor.
      */
-	async reset(): Promise<boolean> {
+	private async reset(): Promise<boolean> {
 		try {
 			const buf: Buffer = Buffer.from(AHT20_CMD_SOFTRESET);
 			await this.bus.i2cWrite(AHT20_I2CADDR, buf.length, buf);
@@ -103,7 +103,7 @@ export default class AHT20 {
      * @returns `true` if successfully calibrated the sensor.
      * @throws An error that occurred while calibrating the sensor.
      */
-	async calibrate(): Promise<boolean> {
+	private async calibrate(): Promise<boolean> {
 		try {
 			const buf: Buffer = Buffer.from(AHT20_CMD_CALIBRATE);
 			await this.bus.i2cWrite(AHT20_I2CADDR, buf.length, buf);
@@ -125,7 +125,7 @@ export default class AHT20 {
      * @returns Information dictionary with temperature and humidity data.
      * @throws An error that occurred while Reading the information.
      */
-	async readData(): Promise<{[key: string]: number}> {
+	private async readData(): Promise<{[key: string]: number}> {
 		try {
 			const buf: Buffer = Buffer.from(AHT20_CMD_MEASURE);
 			await this.bus.i2cWrite(AHT20_I2CADDR, buf.length, buf);
@@ -154,7 +154,7 @@ export default class AHT20 {
      * @returns Temperature gotten from the sensor in Celsius.
      * @throws An error that occurred while getting temperature data.
      */
-	async temperature(): Promise<number> {
+	public async temperature(): Promise<number> {
 		try {
 			const { temperature }: {[key: string]: number} = await this.readData();
 			return temperature;
@@ -168,7 +168,7 @@ export default class AHT20 {
      * @returns Humidity gotten from the sensor in RH%.
      * @throws An error that occurred while getting humidity data.
      */
-	async humidity(): Promise<number> {
+	public async humidity(): Promise<number> {
 		try {
 			const { humidity }: {[key: string]: number} = await this.readData();
 			return humidity;

--- a/AHT20.ts
+++ b/AHT20.ts
@@ -14,13 +14,29 @@ const AHT20_CMD_MEASURE: number[] = [0xAC, 0x33, 0x00]
 const AHT20_STATUS_BUSY: number = 0x80;
 const AHT20_STATUS_CALIBRATED: number = 0x08;
 
+/**
+ * AHT20 sensor class with data read functions.
+ */
 export default class AHT20 {
+    /**
+     * Bus instance.
+     */
     private readonly bus: i2c.PromisifiedBus;
 
+    /**
+     * Constructor
+     * @param bus bus instance
+     */
 	constructor(bus: i2c.PromisifiedBus) {
 		this.bus = bus;
 	}
 
+    /**
+     * Opens i2c bus and connect to the AHT20 sensor.
+     * @param busNumber Target bus number to open. Default is 1.
+     * @returns AHT20 instance with opened bus instance. You can read information with this instance.
+     * @throws An error that occurred while opening i2c bus.
+     */
 	static async open(busNumber: number = 1): Promise<AHT20> {
 		try {
 			const bus: i2c.PromisifiedBus = await i2c.openPromisified(busNumber);
@@ -32,6 +48,11 @@ export default class AHT20 {
 		}
 	}
 
+    /**
+     * Initializes AHT20 sensor.
+     * @returns `true` if successfully initialized the sensor.
+     * @throws An error that occurred while initializing the sensor.
+     */
 	async init(): Promise<boolean> {
 		try {
 			await sleep(20);
@@ -46,6 +67,11 @@ export default class AHT20 {
 		}
 	}
 
+    /**
+     * Gets AHT20 sensor status.
+     * @returns Sensor status
+     * @throws An error that occurred while getting sensor status.
+     */
 	async getStatus(): Promise<number> {
 		try {
 			const buf: Buffer = Buffer.alloc(1);
@@ -56,6 +82,11 @@ export default class AHT20 {
 		}
 	}
 
+    /**
+     * Resets AHT20 sensor.
+     * @returns `true` if successfully reset the sensor.
+     * @throws An error that occurred while resetting the sensor.
+     */
 	async reset(): Promise<boolean> {
 		try {
 			const buf: Buffer = Buffer.from(AHT20_CMD_SOFTRESET);
@@ -67,6 +98,11 @@ export default class AHT20 {
 		}
 	}
 
+    /**
+     * Calibrates AHT20 sensor.
+     * @returns `true` if successfully calibrated the sensor.
+     * @throws An error that occurred while calibrating the sensor.
+     */
 	async calibrate(): Promise<boolean> {
 		try {
 			const buf: Buffer = Buffer.from(AHT20_CMD_CALIBRATE);
@@ -84,6 +120,11 @@ export default class AHT20 {
 		}
 	}
 
+    /**
+     * Reads information from AHT20 sensor.
+     * @returns Information dictionary with temperature and humidity data.
+     * @throws An error that occurred while Reading the information.
+     */
 	async readData(): Promise<{[key: string]: number}> {
 		try {
 			const buf: Buffer = Buffer.from(AHT20_CMD_MEASURE);
@@ -108,6 +149,11 @@ export default class AHT20 {
 		}
 	}
 
+    /**
+     * Gets temperature data from AHT20 sensor.
+     * @returns Temperature gotten from the sensor in Celsius.
+     * @throws An error that occurred while getting temperature data.
+     */
 	async temperature(): Promise<number> {
 		try {
 			const { temperature }: {[key: string]: number} = await this.readData();
@@ -117,6 +163,11 @@ export default class AHT20 {
 		}
 	}
 
+    /**
+     * Gets humidity data from AHT20 sensor.
+     * @returns Humidity gotten from the sensor in RH%.
+     * @throws An error that occurred while getting humidity data.
+     */
 	async humidity(): Promise<number> {
 		try {
 			const { humidity }: {[key: string]: number} = await this.readData();


### PR DESCRIPTION
Thank you for your recent response to my pull request (#2). Today, I will send you another poll request.

## Description
I added [JSDoc (JavaScript Document)](https://jsdoc.app/) and access modifiers.

## Details
### JSDoc
JSDoc is the comment of methods, variables, classes, and etc. which describes what they are or how they work. With this, module users can see descriptions when they use this module.

![image](https://github.com/thomome/aht20-sensor/assets/90630001/0537f5c2-d7f2-4340-86e2-f3314346a4d6)

### Access modifiers
This is one of the [TypeScript](https://www.typescriptlang.org/) features. With this, we can set methods whether module uses can access those methods or not. We can prevent them from accessing unnecessary methods. Currently, only `open()`, `temperature()`, and `humidity()` are visible. If your intentions are different, feel free like to comment to this pull request.

![image](https://github.com/thomome/aht20-sensor/assets/90630001/1c67a1dd-2b9b-4f89-a0ee-a3726d87648e)

Note that this is **only affected to TypeScript**. Although Private methods are still invisible in JavaScript, module users can access them.

![image](https://github.com/thomome/aht20-sensor/assets/90630001/7b78be68-eef7-4c0c-9dff-84f7e79d7de3)

![image](https://github.com/thomome/aht20-sensor/assets/90630001/9ec2d107-b5de-4125-a1c0-7282c38e4c3e)

## How to review
Just write some example codes in JavaScript or TypeScript. You can see the details of the methods and some method are invisible.